### PR TITLE
Update Washington, DC user count

### DIFF
--- a/data/github-cities.geojson
+++ b/data/github-cities.geojson
@@ -5933,8 +5933,8 @@
     "City":"Washington",
     "Country":"United States of America",
     "Population":4955000,
-    "Total":"1407",
-    "Rate":0.02839556
+    "Total":"13608",
+    "Rate": 0.274631685
     }
   },
   {


### PR DESCRIPTION
Search via [this url](https://github.com/search?utf8=%E2%9C%93&q=location%3AWashington+location%3ADC&type=Users) shows 13,680 users